### PR TITLE
Add a guard to protect against why-run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bhanlon@sessiondigital.com, wdolce@sessiondigital.com'
 license 'all_rights'
 description 'Installs/Configures deploy-user'
 long_description 'Installs/Configures deploy-user'
-version '1.4.1'
+version '1.4.2'
 
 depends 'ssh_known_hosts', '~> 0.2'
 depends 'sudo'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,6 +51,7 @@ Chef::Log.debug 'Lock the user so it cannot be directly logged into.'
 user 'Lock deploy user' do
   username node['deploy_user']['user']
   action :lock
+  only_if "passwd -S #{node['deploy_user']['user']}"
 end
 
 directory node['deploy_user']['home'] do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -87,7 +87,9 @@ describe 'deploy-user::default' do
 
   context 'with ssh hosts entries' do
     deploy_known_hosts_path = "#{deploy_ssh_dir}/known_hosts"
-
+    before do
+      stub_command('passwd -S deploy').and_return(252)
+    end
     rsa_key = {
       key_type: 'rsa',
       host: 'example.com',
@@ -127,6 +129,10 @@ describe 'deploy-user::default' do
     end
   end
   context 'with private keys as node attributes' do
+    before do
+      stub_command('passwd -S deploy').and_return(0)
+    end
+
     private_key = {
       filename: 'foo_rsa',
       content: 'some content here'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -16,6 +16,9 @@ describe 'deploy-user::default' do
       runner.converge(described_recipe)
     end
 
+    before do
+      stub_command("passwd -S deploy").and_return(0)
+    end
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end
@@ -66,6 +69,9 @@ describe 'deploy-user::default' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new do |node|
         node.set['deploy_user']['shell'] = false
+      end
+      before do
+        stub_command("passwd -S deploy").and_return(252)
       end
       runner.converge(described_recipe)
     end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -17,7 +17,7 @@ describe 'deploy-user::default' do
     end
 
     before do
-      stub_command("passwd -S deploy").and_return(0)
+      stub_command('passwd -S deploy').and_return(0)
     end
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
@@ -71,7 +71,7 @@ describe 'deploy-user::default' do
         node.set['deploy_user']['shell'] = false
       end
       before do
-        stub_command("passwd -S deploy").and_return(252)
+        stub_command('passwd -S deploy').and_return(252)
       end
       runner.converge(described_recipe)
     end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -66,12 +66,12 @@ describe 'deploy-user::default' do
   end
 
   context 'without a shell specified' do
+    before do
+      stub_command('passwd -S deploy').and_return(252)
+    end
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new do |node|
         node.set['deploy_user']['shell'] = false
-      end
-      before do
-        stub_command('passwd -S deploy').and_return(252)
       end
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
Fixes issue whereby `:lock` appears to be not safe for `--why-run` because it assumes the user must exist.